### PR TITLE
Fix deprecated method: res.send() to res.sendStatus()

### DIFF
--- a/routes/geocode.js
+++ b/routes/geocode.js
@@ -16,7 +16,7 @@ module.exports.query = function(req,res) {
   request.get(url, function(err, resp, body){
     if (err) {
       console.error(err);
-      return res.send(500);
+      return res.sendStatus(500);
     }
 
     if (resp.statusCode !== 200) {


### PR DESCRIPTION
There was a deprecation warning that appeared when I entered an address that forced a 500 error. 
