### PR TITLE
Fixing past migration scripts so that they work on fresh install

### DIFF
--- a/migrations/20150130233457984_add_ward_info.js
+++ b/migrations/20150130233457984_add_ward_info.js
@@ -11,11 +11,11 @@ files.forEach(function(file){
   var path = './data/wards/' + file;
   var raw = require(path);
   ward = {
-    number: parseInt(raw.external_id,10),
-    geometry: raw.simple_shape,
+    number: parseInt(raw.number,10),
+    geometry: raw.geometry,
     alderman: {
-      name: ucwords(raw.metadata.ALDERMAN),
-      phone: raw.metadata.WARD_PHONE
+      name: raw.alderman.name,
+      phone: raw.alderman.voice
     },
     centroid: raw.centroid
   }

--- a/migrations/20160525015732098_update_wards.js
+++ b/migrations/20160525015732098_update_wards.js
@@ -15,9 +15,9 @@ files.forEach(function(file){
     number: parseInt(raw.external_id,10),
     geometry: raw.simple_shape,
     alderman: {
-      name: ucwords(raw.metadata.ALDERMAN),
-      phone: raw.metadata.WARD_PHONE,
-      email: emails[raw.external_id]
+      name: raw.alderman.name,
+      phone: raw.alderman.voice,
+      email: raw.alderman.email
     },
     centroid: raw.centroid
   }


### PR DESCRIPTION
The `wardX.json` files used to have a different syntax; and past migrations in the current codebase use those files to register data. Now, the JSON files have changed, so those migrations couldn't run anymore.

The issue didn't affect environments that had already ran the migrations at the time, only those who hadn't yet, so, most likely, only fresh installs.