### PR TITLE
No need for cluster in dev

### DIFF
--- a/server.js
+++ b/server.js
@@ -62,7 +62,7 @@ app.get('/locations/count.json', locations.count);
 app.use(require('./routes/wards.js'));
 
 
-if (cluster.isMaster) {
+if (env != 'development' && cluster.isMaster) {
   for (var i = 0; i < concurrency; i++) {
     cluster.fork();
   }


### PR DESCRIPTION
I know what the `cluster` package solves (crazy that node.js is single-threaded, when there are alternatives like Go or Rust, but eh); but I don't know much about how it works. I read a bit about it this morning, but it didn't inform much about how to solve my specific problem, so I'm not 100% sure I'm doing it right.

Basically: `cluster.isMaster` resolves to `true` in dev, and since the HTTP listening is stated in the `else` of that thing, the listening was never even started in my dev environment. So, I just changed the condition so that `cluster` is never used in dev (arguably, it's only useful in production anyway); the downside is that it makes an application-level difference with production, which I know is not ideal, so feel free to interject.

The upside is: all issues solved, my environment is entirely up now. :)