### PR TITLE
Add migrate:all in install doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Requirements
 Getting Started
 ---------------
 For more detailed instructions see the [wiki](https://github.com/open-city/recycling/wiki)
+
 * install dependencies
   `npm install`
+* Run the schema migrations
+  `npm migrate:all`
 * Run `mongod` and `memcached` on default ports
 * run the app
   `node server.js`


### PR DESCRIPTION
Added in README.md:
 * a word about `npm migrate:all` (I had to "guess" it from reading the packages docs).
 • added a new line before list to be compatible with other Markdown editors (Mou wasn't "getting" the list).